### PR TITLE
Allow empty „certificates“ list in TLSConfig

### DIFF
--- a/Sources/Security/TLSConfig.swift
+++ b/Sources/Security/TLSConfig.swift
@@ -40,7 +40,7 @@ extension TLSConfig {
     }
 
     // Set the certificate
-    if !certificates.isEmpty {
+    if !allCertificates.isEmpty {
       rawConfig[kCFStreamSSLCertificates as String] = allCertificates as CFArray
     }
 


### PR DESCRIPTION
Hi! I'm not 100% sure whether this is change is "correct", but I noticed that passing an empty list for the "certificates" argument of TLSConfig leads to the server starting without error, but all HTTPS connections failing. With this change, the server starts correctly and allows connections with just an CertificateIdentity and no further (CA) certificates.

Anyway, thanks for making Telegraph available. I was looking for an macOS and iOS-compatible HTTPS server, and Kitura was just a big hassle to integrate with an existing hybrid macOS/iOS project, while Telegraph integrated just fine using CocoaPods.