### PR TITLE
Enable binding the server to a specific interface

### DIFF
--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -32,8 +32,8 @@ open class Server {
   }
 
   /// Starts the server on the specified port.
-  open func start(onPort port: UInt16) throws {
-    try listener.accept(onPort: port)
+  open func start(onInterface interface: String? = nil, onPort port: UInt16) throws {
+    try listener.accept(onInterface: interface, onPort: port)
   }
 
   /// Stops the server, optionally we wait for requests to finish.

--- a/Sources/Transport/TCPListener.swift
+++ b/Sources/Transport/TCPListener.swift
@@ -30,8 +30,8 @@ public final class TCPListener: NSObject {
     socket.setDelegate(self, delegateQueue: socketDelegateQueue)
   }
 
-  public func accept(onPort port: UInt16) throws {
-    try socket.accept(onPort: port)
+  public func accept(onInterface interface: String? = nil, onPort port: UInt16) throws {
+    try socket.accept(onInterface: interface, port: port)
   }
 
   public func disconnect() {

--- a/Telegraph.podspec
+++ b/Telegraph.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Telegraph'
-  s.version = '0.6.1'
+  s.version = '0.6.0'
 
   s.license = { :type => 'MPL2', :file => 'LICENSE' }
   s.summary = 'A Secure Web Server for iOS, tvOS and macOS'

--- a/Telegraph.podspec
+++ b/Telegraph.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Telegraph'
-  s.version = '0.6.0'
+  s.version = '0.6.1'
 
   s.license = { :type => 'MPL2', :file => 'LICENSE' }
   s.summary = 'A Secure Web Server for iOS, tvOS and macOS'


### PR DESCRIPTION
When using a Telegraph server on an iOS device, it automatically binds the server to the device’s IP address. This means the server is accessible from outside the device, meaning you can always connect to it from another device. This may not be desired for some applications, as it could pose a security concern.

I’ve added an option to specify the interface the server should accept connections from.
By default, I’ve set the interface to nil, which is the same as calling accept(onPort…).
This enables apps to bind the server to 127.0.0.1, so that it won’t be accessible outside the device.
If the interface is not specified, the behavior simply remains the same as before this change.