### PR TITLE
Server property to return the listening port

### DIFF
--- a/Examples/Demo/TelegraphDemo.swift
+++ b/Examples/Demo/TelegraphDemo.swift
@@ -53,7 +53,7 @@ class TelegraphDemo: NSObject {
 
     // Start the server on localhost, we'll skip error handling for the demo
     // Note: if you test in your browser, don't forget to type https://
-    try! server.start(onPort: 0)
+    try! server.start()
     serverLog("Server is running at https://localhost:\(server.port)")
   }
 

--- a/Examples/Demo/TelegraphDemo.swift
+++ b/Examples/Demo/TelegraphDemo.swift
@@ -54,20 +54,20 @@ class TelegraphDemo: NSObject {
     // Start the server on localhost, we'll skip error handling for the demo
     // Note: if you test in your browser, don't forget to type https://
     try! server.start(onPort: 0)
-    serverLog("Server is running at https://localhost:\(server.listeningPort)")
+    serverLog("Server is running at https://localhost:\(server.port)")
   }
 
   func demoClientRequest() {
     // Demonstrate a request on the /hello endpoint with (NS)URLSession
     // Note: we are setting ourself as the delegate to customize the SSL handshake
     let httpClient = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-    let httpTask = httpClient.dataTask(with: URL(string: "https://localhost:\(server.listeningPort)/hello")!, completionHandler: clientHandleGreeting)
+    let httpTask = httpClient.dataTask(with: URL(string: "https://localhost:\(server.port)/hello")!, completionHandler: clientHandleGreeting)
     httpTask.resume()
   }
 
   func demoWebSocketConnect() {
     // Demonstrate a WebSocket client connection
-    webSocketClient = try! WebSocketClient("wss://localhost:\(server.listeningPort)", certificates: [caCertificate])
+    webSocketClient = try! WebSocketClient("wss://localhost:\(server.port)", certificates: [caCertificate])
     webSocketClient.delegate = self
     webSocketClient.headers.webSocketProtocol = "myProtocol"
     webSocketClient.headers["X-Name"] = "Yvo"

--- a/Examples/Demo/TelegraphDemo.swift
+++ b/Examples/Demo/TelegraphDemo.swift
@@ -53,21 +53,21 @@ class TelegraphDemo: NSObject {
 
     // Start the server on localhost, we'll skip error handling for the demo
     // Note: if you test in your browser, don't forget to type https://
-    try! server.start(onPort: 9000)
-    serverLog("Server is running at https://localhost:9000")
+    try! server.start(onPort: 0)
+    serverLog("Server is running at https://localhost:\(server.listeningPort)")
   }
 
   func demoClientRequest() {
     // Demonstrate a request on the /hello endpoint with (NS)URLSession
     // Note: we are setting ourself as the delegate to customize the SSL handshake
     let httpClient = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-    let httpTask = httpClient.dataTask(with: URL(string: "https://localhost:9000/hello")!, completionHandler: clientHandleGreeting)
+    let httpTask = httpClient.dataTask(with: URL(string: "https://localhost:\(server.listeningPort)/hello")!, completionHandler: clientHandleGreeting)
     httpTask.resume()
   }
 
   func demoWebSocketConnect() {
     // Demonstrate a WebSocket client connection
-    webSocketClient = try! WebSocketClient("wss://localhost:9000", certificates: [caCertificate])
+    webSocketClient = try! WebSocketClient("wss://localhost:\(server.listeningPort)", certificates: [caCertificate])
     webSocketClient.delegate = self
     webSocketClient.headers.webSocketProtocol = "myProtocol"
     webSocketClient.headers["X-Name"] = "Yvo"

--- a/Examples/macOS Example/Info.plist
+++ b/Examples/macOS Example/Info.plist
@@ -22,6 +22,11 @@
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Building42. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -52,6 +52,11 @@ open class Server {
     }
   }
 
+  /// Returns the port on which the listener is accepting connections.
+  open var listeningPort: UInt16 {
+    return listener.listeningPort
+  }
+
   /// Handles an incoming HTTP request.
   private func handle(request: HTTPRequest, error: Error?) -> HTTPResponse? {
     do {

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -53,8 +53,8 @@ open class Server {
   }
 
   /// Returns the port on which the listener is accepting connections.
-  open var listeningPort: UInt16 {
-    return listener.listeningPort
+  open var port: UInt16 {
+    return listener.port
   }
 
   /// Handles an incoming HTTP request.

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -32,12 +32,12 @@ open class Server {
   }
 
   /// Starts the server on the specified port.
-  open func start(onPort port: UInt16) throws {
+  open func start(onPort port: UInt16 = 0) throws {
     try listener.accept(onPort: port)
   }
 
   /// Starts the server on the specified network interface and port.
-  open func start(onInterface interface: String?, port: UInt16) throws {
+  open func start(onInterface interface: String?, port: UInt16 = 0) throws {
     try listener.accept(onInterface: interface, port: port)
   }
 

--- a/Sources/Transport/TCPListener.swift
+++ b/Sources/Transport/TCPListener.swift
@@ -42,7 +42,7 @@ public final class TCPListener: NSObject {
     socket.disconnect()
   }
 
-  public var listeningPort: UInt16 {
+  public var port: UInt16 {
     return socket.localPort
   }
 }

--- a/Sources/Transport/TCPListener.swift
+++ b/Sources/Transport/TCPListener.swift
@@ -41,6 +41,10 @@ public final class TCPListener: NSObject {
   public func disconnect() {
     socket.disconnect()
   }
+
+  public var listeningPort: UInt16 {
+    return socket.localPort
+  }
 }
 
 // MARK: TCPListener GCDAsyncSocketDelegate


### PR DESCRIPTION
When publishing the HTTP server via Bonjour, it's common to pass 0 for the port number and let the system choose a high number port for you. This is readily available from GCDAsyncSocket, it just wasn't exposed by the Server class.