### PR TITLE
Server Disconnecting Delegate Call

### DIFF
--- a/Examples/Demo/TelegraphDemo.swift
+++ b/Examples/Demo/TelegraphDemo.swift
@@ -124,6 +124,10 @@ extension TelegraphDemo: ServerWebSocketDelegate {
   func server(_ server: Server, webSocket: WebSocket, didSendMessage message: WebSocketMessage) {
     serverLog("WebSocket sent message: \(message)")
   }
+  
+  func serverDidDisconnect(_ server: Server) {
+    serverLog("Server disconnected")
+  }
 }
 
 // MARK: - URLSessionDelegate implementation

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -106,6 +106,13 @@ extension Server: TCPListenerDelegate {
       httpConnection.open()
     }
   }
+  
+  public func listenerSocketDisconnected(_ listener: TCPListener) {
+    delegateQueue.async(weak: self) { server in
+      server.webSocketDelegate?.serverDidDisconnect(self)
+    }
+  }
+  
 }
 
 // MARK: HTTPConnectionDelegate implementation

--- a/Sources/Server/ServerWebSocketDelegate.swift
+++ b/Sources/Server/ServerWebSocketDelegate.swift
@@ -14,6 +14,9 @@ public protocol ServerWebSocketDelegate: class {
 
   func server(_ server: Server, webSocket: WebSocket, didReceiveMessage message: WebSocketMessage)
   func server(_ server: Server, webSocket: WebSocket, didSendMessage message: WebSocketMessage)
+  
+  /// Called when the main listener for the server has disconnected, this should result in the server completely disconnecting
+  func serverDidDisconnect(_ server: Server)
 }
 
 // MARK: Default implementation

--- a/Sources/Transport/TCPListener.swift
+++ b/Sources/Transport/TCPListener.swift
@@ -11,6 +11,9 @@ import CocoaAsyncSocket
 
 public protocol TCPListenerDelegate: class {
   func listener(_ listener: TCPListener, didAcceptSocket socket: TCPSocket)
+	
+  /// Called when the main socket for a TCPListener has disconnected
+  func listenerSocketDisconnected(_ listener: TCPListener)
 }
 
 public final class TCPListener: NSObject {
@@ -59,5 +62,11 @@ extension TCPListener: GCDAsyncSocketDelegate {
     }
 
     delegate?.listener(self, didAcceptSocket: socket)
+  }
+  
+  public func socketDidDisconnect(_ sock: GCDAsyncSocket, withError err: Error?) {
+    /// We are disconnecting everything so notify the server that we are disconnected
+    guard sock == socket else { return }
+    delegate?.listenerSocketDisconnected(self)
   }
 }


### PR DESCRIPTION
Added some delegate calls to inform the delegate on the Server when the servers listener socket was disconnected resulting in the server no longer being connected. This is useful so you know when the server has its listener socket disconnected and you can attempt to start up a new server. 