### PR TITLE
remove macOS firewall permissions dialog by accepting with network interface

### DIFF
--- a/Examples/Demo/TelegraphDemo.swift
+++ b/Examples/Demo/TelegraphDemo.swift
@@ -80,7 +80,7 @@ extension TelegraphDemo {
 
     // Start the server on localhost
     // Note: we'll skip error handling in the demo
-    try! server.start(port: 9000)
+    try! server.start(port: 9000, interface: "localhost")
 
     // Log the url for easy access
     print("[SERVER]", "Server is running - url:", serverURL())

--- a/Sources/Transport/TCPListener.swift
+++ b/Sources/Transport/TCPListener.swift
@@ -59,7 +59,7 @@ public final class TCPListener: NSObject {
   /// Starts the listener with a queue to perform the delegate calls on.
   public func start(queue: DispatchQueue) throws {
     listenerSocket.setDelegate(self, delegateQueue: queue)
-    try listenerSocket.accept(onPort: listenerPort)
+    try listenerSocket.accept(onInterface: interface, port: listenerPort)
   }
 
   /// Stops the listener.


### PR DESCRIPTION
I was trying to run the server on Mojave within an XCTestCase for a UI test, and I was getting a permissions dialog.

I had a look at the `GCDAsyncSocket` class and there's an alternative `accept` method that allows you to pass the interface string through. I think if you pass in the "localhost" interface, macOS (on Mojave at least) doesn't show this permissions dialog, as it accepts requests on `INADDR_LOOPBACK`:

https://github.com/robbiehanson/CocoaAsyncSocket/blob/b179ea4013e94e31e6e637955e520ea4fb9d1b13/Source/GCD/GCDAsyncSocket.m#L4105

I've compared this behaviour to GCDWebServer, and I think this is the same:

https://github.com/swisspol/GCDWebServer/blob/acdb5c92624e3748009b1ca9c2f339adda168aa9/GCDWebServer/Core/GCDWebServer.m#L529