### PR TITLE
fixed the query parameters encode twice.

### DIFF
--- a/Sources/Clients/WebSocketClient.swift
+++ b/Sources/Clients/WebSocketClient.swift
@@ -86,7 +86,7 @@ open class WebSocketClient: WebSocket {
   /// Performs a handshake to initiate the websocket connection.
   private func performHandshake(socket: TCPSocket) {
     // Create the handshake request
-    let requestURI = URI(path: url.path, query: url.query)
+    let requestURI = URI(path: url.path, queryItems: URLComponents(string: url.absoluteString)?.queryItems)
     let handshakeRequest = HTTPRequest(uri: requestURI, headers: headers)
     handshakeRequest.webSocketHandshake(host: endpoint.host, port: endpoint.port)
 

--- a/Sources/Clients/WebSocketClient.swift
+++ b/Sources/Clients/WebSocketClient.swift
@@ -86,7 +86,7 @@ open class WebSocketClient: WebSocket {
   /// Performs a handshake to initiate the websocket connection.
   private func performHandshake(socket: TCPSocket) {
     // Create the handshake request
-    let requestURI = URI(path: url.path, queryItems: URLComponents(string: url.absoluteString)?.queryItems)
+    let requestURI = URI(path: url.path, query: url.query)
     let handshakeRequest = HTTPRequest(uri: requestURI, headers: headers)
     handshakeRequest.webSocketHandshake(host: endpoint.host, port: endpoint.port)
 

--- a/Sources/Transport/URI.swift
+++ b/Sources/Transport/URI.swift
@@ -77,6 +77,6 @@ public extension URI {
 
 extension URI: CustomStringConvertible {
   public var description: String {
-    return components.description
+    return components.url?.relativeString ?? "/"
   }
 }

--- a/Sources/Transport/URI.swift
+++ b/Sources/Transport/URI.swift
@@ -12,15 +12,15 @@ public struct URI {
   private var components: URLComponents
 
   /// Creates a URI from the provided path, query string.
-  public init(path: String = "/", queryItems: [URLQueryItem]? = nil) {
+  public init(path: String = "/", query: String? = nil) {
     self.components = URLComponents()
     self.path = path
-    self.queryItems = queryItems
+    self.query = query
   }
 
   /// Creates a URI from URLComponents. Takes only the path, query string.
   public init(components: URLComponents) {
-    self.init(path: components.path, queryItems: components.queryItems)
+    self.init(path: components.path, query: components.query)
   }
 
   /// Creates a URI from the provided URL. Takes only the path, query string and fragment.
@@ -45,7 +45,8 @@ public extension URI {
 
   /// The query string of the URI (e.g. lang=en&page=home). Does not contain a question mark.
   var query: String? {
-    get { return components.query }    
+    get { return components.query }
+    set { components.queryItems = URLComponents(string: "?\(newValue ?? "")")?.queryItems }
   }
 
   /// The query string items of the URI as an array.

--- a/Sources/Transport/URI.swift
+++ b/Sources/Transport/URI.swift
@@ -12,15 +12,15 @@ public struct URI {
   private var components: URLComponents
 
   /// Creates a URI from the provided path, query string.
-  public init(path: String = "/", query: String? = nil) {
+  public init(path: String = "/", queryItems: [URLQueryItem]? = nil) {
     self.components = URLComponents()
     self.path = path
-    self.query = query
+    self.queryItems = queryItems
   }
 
   /// Creates a URI from URLComponents. Takes only the path, query string.
   public init(components: URLComponents) {
-    self.init(path: components.path, query: components.query)
+    self.init(path: components.path, queryItems: components.queryItems)
   }
 
   /// Creates a URI from the provided URL. Takes only the path, query string and fragment.
@@ -45,8 +45,7 @@ public extension URI {
 
   /// The query string of the URI (e.g. lang=en&page=home). Does not contain a question mark.
   var query: String? {
-    get { return components.query }
-    set { components.query = newValue }
+    get { return components.query }    
   }
 
   /// The query string items of the URI as an array.

--- a/Telegraph.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Telegraph.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/Building42/HTTPParserC",
         "state": {
           "branch": null,
-          "revision": "27a769a453f32fccd800d905fcf939bac821e4d3",
+          "revision": "6fa23997359a65eccfc06808ab85f2e121a84290",
           "version": "2.9.2"
         }
       }


### PR DESCRIPTION
When setting the `query ` in `URLComponents`, the system will encode the query. So if the URL contains the query that already encoded, it will encode it twice.

The `description` in `URI.swift` is not right when the URL is long. It is partly omitted with `...`

[Apple Document Reference](https://developer.apple.com/documentation/foundation/urlcomponents/1780254-query)