### PR TITLE
Catching webassembly file extensions to return correct mimeType

### DIFF
--- a/Sources/Helpers/Extensions/FileManager+Ext.swift
+++ b/Sources/Helpers/Extensions/FileManager+Ext.swift
@@ -17,6 +17,12 @@ public extension FileManager {
   func mimeType(of url: URL) -> String {
     let fallback = "application/octet-stream"
     let fileExt = url.pathExtension as CFString
+    
+    // Wasm extensions must return `application/wasm`
+    // Or else browsers will throw an error 
+    if fileExt as String == "wasm" {
+        return "application/wasm"
+    }
 
     guard let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExt, nil)?.takeRetainedValue() else { return fallback }
     guard let mimeType = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() else { return fallback }


### PR DESCRIPTION
1. `.wasm` must return `application/wasm` or else browsers will throw an error
2. Currently `application/octet-stream` is being returned for any unknown mimeTypes
3. This fixes #94 