### PR TITLE
Update Package.swift - semantic versioning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/robbiehanson/CocoaAsyncSocket.git", from: "7.6"),
-        .package(url: "https://github.com/Building42/HTTPParserC.git", from: "2.9")
+        .package(url: "https://github.com/robbiehanson/CocoaAsyncSocket.git", from: "7.6.5"),
+        .package(url: "https://github.com/Building42/HTTPParserC.git", from: "2.9.4")
     ],
     targets: [
         .target(


### PR DESCRIPTION
using semantic versioning for dependencies; both dependencies dropping support for iOS 8

![telegraph semantic versioning problem](https://user-images.githubusercontent.com/20605395/115459226-6b54b780-a1ec-11eb-89dd-f203018833c4.png)
