### PR TITLE
Send a response in multiple chunks

### DIFF
--- a/Sources/Protocols/HTTP/Models/HTTPConnection.swift
+++ b/Sources/Protocols/HTTP/Models/HTTPConnection.swift
@@ -86,7 +86,7 @@ public class HTTPConnection: TCPConnection {
     }
 
     // Close the connection after writing if not keep-alive
-    if !response.keepAlive {
+    if !response.keepAlive && response.isComplete {
       close(immediately: false)
     }
   }

--- a/Sources/Protocols/HTTP/Models/HTTPResponse.swift
+++ b/Sources/Protocols/HTTP/Models/HTTPResponse.swift
@@ -13,10 +13,13 @@ open class HTTPResponse: HTTPMessage {
 
   public var status: HTTPStatus
 
+  internal let isComplete: Bool
+
   /// Initializes a new HTTPResponse
   public init(_ status: HTTPStatus = .ok, version: HTTPVersion = .default,
-              headers: HTTPHeaders = .empty, body: Data = Data()) {
+              headers: HTTPHeaders = .empty, body: Data = Data(), isComplete: Bool = true) {
     self.status = status
+    self.isComplete = isComplete
     super.init(version: version, headers: headers, body: body)
   }
 
@@ -32,12 +35,15 @@ open class HTTPResponse: HTTPMessage {
     // Set the date header
     headers.date = Date().rfc1123
 
-    // If a body is allowed set the content length (even when 0)
-    if status.supportsBody {
-      headers.contentLength = body.count
-    } else {
-      headers.contentLength = nil
-      body.count = 0
+    // A reponse might be followed by more data
+    if isComplete {
+      // If a body is allowed set the content length (even when 0)
+      if status.supportsBody {
+        headers.contentLength = body.count
+      } else {
+        headers.contentLength = nil
+        body.count = 0
+      }
     }
   }
 }


### PR DESCRIPTION
A custom `Server` implementation can now send large responses in multiple chunks.

Before this change calling `HTTPConnection.send(response:toRequest:)` would send given
headers and body, then close the connection (except for keep-alive connections).

Now a call to `send(response:toRequest:)` with a response that has `isComplete` set to false
can be followed with `send(data:timeout:)` calls.

Note that in such case the connection needs to be closed explicitly by calling
`HTTPConnection.close(immediately:)`. Also, a content-length header should be set manually
if it's required.