### PR TITLE
Fix "HEAD" Request Issue

### DIFF
--- a/Sources/Protocols/HTTP/Models/HTTPParser+Raw.swift
+++ b/Sources/Protocols/HTTP/Models/HTTPParser+Raw.swift
@@ -21,7 +21,7 @@ extension HTTPRawParser {
   /// Creates a new HTTPRawParser.
   static func make() -> HTTPRawParser {
     var parser = HTTPRawParser()
-    http_parser_init(&parser, HTTP_BOTH)
+    http_parser_init(&parser, HTTP_REQUEST)
     return parser
   }
 
@@ -35,7 +35,7 @@ extension HTTPRawParser {
 
   /// Resets the parser.
   static func reset(parser: UnsafeMutablePointer<HTTPRawParser>) {
-    http_parser_init(parser, HTTP_BOTH)
+    http_parser_init(parser, HTTP_REQUEST)
   }
 
   /// Returns the context.


### PR DESCRIPTION
**Summary**
This pull request addresses the issue with the "HEAD" request not working by changing the http_parser_init function's parameter from HTTP_BOTH to HTTP_REQUEST. This change ensures that the "HEAD" request is correctly processed, resolving the previous problem.

**Details**
In the current implementation, the http_parser_init function is invoked with the parameter HTTP_BOTH, which handles both requests and responses. However, this causes a specific issue with the "HEAD" request, preventing it from functioning correctly. By changing the parameter to HTTP_REQUEST, we explicitly instruct the parser to handle only HTTP requests.

This change has been tested and has been found to fix the "HEAD" request issue as expected.

**Testing**
To verify the effectiveness of this fix, I ran comprehensive test cases covering various HTTP methods, including "HEAD" requests, using the updated http_parser_init with HTTP_REQUEST. All tests passed successfully, and the "HEAD" requests now return the expected responses.

**Additional Observations**
While investigating the issue, I noticed a similar initialization in a forked framework [http-parser](https://github.com/nodejs/http-parser/tree/main), specifically in the test.c file of the HTTP_REQUEST fork.

**Closing Remarks**
This contribution aims to improve the overall functionality of the repository by fixing the "HEAD" request issue. I have thoroughly tested the changes and ensured that they are in compliance with the coding standards of the project.

Looking forward to feedback and further discussion on this improvement. Thank you for reviewing this pull request.